### PR TITLE
Access status-bar through new service API

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -32,13 +32,6 @@ module.exports =
         atom.commands.dispatch(workspaceView, 'incompatible-packages:clear-cache')
         atom.commands.dispatch(workspaceView, 'window:reload')
 
-    if statusBar = document.querySelector('status-bar')
-      createStatusBarView(statusBar)
-    else
-      atom.packages.onDidActivateInitialPackages ->
-        statusBar = document.querySelector('status-bar')
-        createStatusBarView(statusBar) if statusBar?
-
   deactivate: ->
     incompatiblePackagesStatusView?.destroy()
     incompatiblePackagesStatusView = null
@@ -49,11 +42,11 @@ module.exports =
     workspaceSubscription?.dispose()
     workspaceSubscription = null
 
-createStatusBarView = (statusBar) ->
-  incompatibleCount = 0
-  for pack in atom.packages.getLoadedPackages()
-    incompatibleCount++ unless pack.isCompatible()
+  consumeStatusBar: (statusBar) ->
+    incompatibleCount = 0
+    for pack in atom.packages.getLoadedPackages()
+      incompatibleCount++ unless pack.isCompatible()
 
-  if incompatibleCount > 0
-    IncompatiblePackagesStatusView = require './incompatible-packages-status-view'
-    incompatiblePackagesStatusView ?= new IncompatiblePackagesStatusView(statusBar, incompatibleCount)
+    if incompatibleCount > 0
+      IncompatiblePackagesStatusView = require './incompatible-packages-status-view'
+      incompatiblePackagesStatusView ?= new IncompatiblePackagesStatusView(statusBar, incompatibleCount)

--- a/package.json
+++ b/package.json
@@ -11,5 +11,12 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
     "underscore-plus": "^1"
+  },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^0.58.0": "consumeStatusBar"
+      }
+    }
   }
 }


### PR DESCRIPTION
:warning: Depends on https://github.com/atom/status-bar/pull/51 being merged and released in Atom v0.178 :warning:

Signed-off-by: Jessica Lord <jlord@github.com>